### PR TITLE
Fix Python invocation

### DIFF
--- a/budget/budget.py
+++ b/budget/budget.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 import os.path
 import sys


### PR DESCRIPTION
It's best to use "/usr/bin/env python3" for invocation, as it's more portable.